### PR TITLE
Add support for `transform-origin`

### DIFF
--- a/examples/tests/index.html
+++ b/examples/tests/index.html
@@ -302,6 +302,17 @@
     </div>
   </div>
 
+  <div class="test">
+    <div class="test__info">
+      <h2>Origin test</h2>
+    </div>
+    <div class="test__output">
+      <x-model class="model model--small" src="../assets/models/LeePerrySmith.obj" style="transform-origin: 0 0 0;animation: 5s spin-z linear infinite"></x-model>
+      <x-model class="model model--small" src="../assets/models/LeePerrySmith.obj" style="transform-origin: 50% 50% -140px;animation: 5s spin-x linear infinite"></x-model>
+      <x-model class="model model--small" src="../assets/models/LeePerrySmith.obj" style="transform-origin: 100% 100% 0;animation: 5s spin-z linear infinite"></x-model>
+    </div>
+  </div>
+
   <div class="test test--2">
     <div class="test__info">
       <h2>Perspective test</h2>

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,6 @@ This is a experimental custom element that allows 3D objects (.obj format) to be
 
 * Only supports then `.obj` model file format - other loaders will be added in the future.
 * At the moment Safari doesn't scroll models because of a bug with `scrollTop`.
-* `transform-origin` isn't supported yet.
 * `perspective-origin` isn't supported yet.
 * `transform-style: flat` isn't supported yet.
 


### PR DESCRIPTION
* Adds support for applying transforms using the `transform-origin` CSS property.
* Removes the 'decompse -> invert Y rotation sign -> recompose' step when computing matrices. This is now done when parsing the CSS matrix of an element.
* Adds an example to the test page.