### PR TITLE
Container element scroll clipping & perspective

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,7 @@ Here's a cut-and-paste example:
 
 ### Positioning models
 
-Models can be positioned and rotated using CSS transforms. Any transforms applied to a model element will also be applied to the model.
+Models can be positioned and rotated using CSS transforms. Any transforms applied to a model element will also be applied to the model. 
 
 ```css
 .model {
@@ -73,12 +73,7 @@ Models can be positioned and rotated using CSS transforms. Any transforms applie
 }
 ```
 
-### A note on perspective
-
-If you have a `perspective` property value defined in your CSS, the model element will use it to render the object with the correct perspective. Omitting `perspective` (or setting it to zero) will result in objects rendered with orthographic projection.
-
-
-_Note: It's perfectly valid to nest perspective rules in CSS. However, models will only use the first perspective definition when walking up the DOM tree._
+If a model element has an ancestor with a valid `perspective` / `perspective-origin` style property, the model will be renderered using perspective projection. Omitting `perspective` (or setting it to zero) will result in objects being rendered with orthographic projection.
 
 
 ---
@@ -87,7 +82,7 @@ _Note: It's perfectly valid to nest perspective rules in CSS. However, models wi
 
 The model-element script creates a camera, scene, light source and a WebGL renderer. The DOM node returned by the renderer (a `<canvas>` element) is added to the document and configured to fill the viewport and sit above all other content. Additionally, `pointer-events: none` is set, allowing elements below to be interacted with.
 
-Adding `<x-model>` elements to the DOM results in the model being loaded and added to the underling scene. Removing an element from the DOM will remove it from the scene.
+Adding `<x-model>` elements to the DOM results in the model being loaded and added to the underlying scene. Removing an element from the DOM will remove it from the scene.
 
 The scene is re-rendered every frame. For each object in the scene, the renderer finds it's host node and walks up the DOM tree resolving any transforms, positions and scroll offsets. The resulting transform matrix is then applied to the object in the scene. Once all objects are updated the renderer repaints the scene to the layer. Objects now appear on-screen, synchronised with their host DOM node.
 
@@ -105,10 +100,10 @@ The scene is re-rendered every frame. For each object in the scene, the renderer
 
 1) Clone this repo.
 2) Install dependencies: `npm install`
-3) Build the project with the watch task: `npm start dev`
+3) Build the project with the watch task: `npm run dev`
 4) Start editing...
 
 
 ## Other build options
 
-* `npm start dist` - builds the both the unminified and minified distribution files to the `/dist/` folder.
+* `npm run dist` - builds the both the unminified and minified distribution files to the `/dist/` folder.

--- a/src/modelLayer.js
+++ b/src/modelLayer.js
@@ -37,7 +37,7 @@ const init = () => {
   requestAnimationFrame(render);
 
   return renderer.domElement;
-}
+};
 
 
 const add = obj => {
@@ -47,7 +47,7 @@ const add = obj => {
     return true;
   }
   return false;
-}
+};
 
 
 const remove = (obj) => {
@@ -57,7 +57,7 @@ const remove = (obj) => {
     return true;
   }
   return false;
-}
+};
 
 
 const update = () => {
@@ -105,7 +105,7 @@ const update = () => {
       // Three's coordinate space uses 0,0,0 as the screen centre so we need
       // to adjust the computed X/Y position back to the top-left of the screen
       // to match the CSS rendering position.
-      child.position.x += width - overlayWidth / 2;;
+      child.position.x += width - overlayWidth / 2;
       child.position.y += overlayHeight / 2;
 
       // Determine which camera to use to project this model and set its
@@ -135,7 +135,7 @@ const update = () => {
   });
 
   return !!camera;
-}
+};
 
 
 const setOrthographicCamera = () => {
@@ -146,8 +146,8 @@ const setOrthographicCamera = () => {
   } 
   
   camera = orthographicCamera;
-  camera.left = -overlayWidth / 2;;
-  camera.right = overlayWidth / 2;;
+  camera.left = -overlayWidth / 2;
+  camera.right = overlayWidth / 2;
   camera.top = overlayHeight / 2;
   camera.bottom = -overlayHeight / 2;
   camera.far = 2000;
@@ -155,7 +155,7 @@ const setOrthographicCamera = () => {
   camera.updateProjectionMatrix();
 
   return camera;
-}
+};
 
 
 const setPerspectiveCamera = (bounds, perspective, perspectiveOrigin) => {
@@ -201,13 +201,13 @@ const setPerspectiveCamera = (bounds, perspective, perspectiveOrigin) => {
   }
 
   return camera;
-}
+};
 
 
 const render = () => {
   requestAnimationFrame(render);
   update();
-}
+};
 
 
 export default {
@@ -215,4 +215,4 @@ export default {
   add,
   remove,
   render
-}
+};

--- a/src/modelLayer.js
+++ b/src/modelLayer.js
@@ -10,6 +10,8 @@ let renderer;
 let scene;
 let light;
 
+const objs = [];
+
 
 const init = () => {
   if (scene) {
@@ -37,16 +39,24 @@ const init = () => {
   return renderer.domElement;
 }
 
-const objs = []
 
 const add = obj => {
-  objs.push(obj)
-  //scene.add(obj);
+  let index = objs.indexOf(obj);
+  if (index === -1) {
+    objs.push(obj);
+    return true;
+  }
+  return false;
 }
 
 
 const remove = (obj) => {
-  scene.remove(obj);
+  let index = objs.indexOf(obj);
+  if (index > -1) {
+    objs.splice(index, 1);
+    return true;
+  }
+  return false;
 }
 
 

--- a/src/modelLoader.js
+++ b/src/modelLoader.js
@@ -10,7 +10,7 @@ const register = (ext, handler) => {
     load: handler,
     objectCache: {}
   };
-}
+};
 
 
 const load = src => {
@@ -42,7 +42,7 @@ const load = src => {
   }
   
   return object.then(model => model.clone());
-}
+};
 
 
 export default {

--- a/src/utils/css.js
+++ b/src/utils/css.js
@@ -4,7 +4,7 @@
  */
 const parseUnitValue = value => {
   return parseFloat(value || 0);
-}
+};
 
 
 /**
@@ -19,7 +19,7 @@ const parseOriginValue = (originString, vec3) => {
     parseUnitValue(transformOrigin[1]),
     parseUnitValue(transformOrigin[2])
   );
-}
+};
 
 
 /**
@@ -29,33 +29,34 @@ const parseOriginValue = (originString, vec3) => {
  * (https://keithclark.co.uk/articles/calculating-element-vertex-data-from-css-transforms/)
  */
 
-  const parseTransformValue = (matrixString, mat4) => {
-    var c = matrixString.split(/\s*[(),]\s*/).slice(1, -1);
+const parseTransformValue = (matrixString, mat4) => {
+  var c = matrixString.split(/\s*[(),]\s*/).slice(1, -1);
 
-    if (c.length === 6) {
-      // 'matrix()' (3x2)
-      mat4.set(
-        +c[0], -c[2],      0,  +c[4],
-        -c[1], +c[3],      0,  -c[5],
-            0,     0,      1,      0,
-            0,     0,      0,      1
-      );
-    } else if (c.length === 16) { 
-      // matrix3d() (4x4)
-      mat4.set(
-        +c[0], -c[4],  +c[8], +c[12],
-        -c[1], +c[5],  -c[9], -c[13],
-        +c[2], -c[6], +c[10], +c[14],
-        +c[3], +c[7], +c[11], +c[15]
-      );
-    } else {
-      // handle 'none' or invalid values.
-      mat4.identity();
-    }
-  };
+  if (c.length === 6) {
+    // 'matrix()' (3x2)
+    mat4.set(
+      +c[0], -c[2],      0,  +c[4],
+      -c[1], +c[3],      0,  -c[5],
+          0,     0,      1,      0,
+          0,     0,      0,      1
+    );
+  } else if (c.length === 16) {
+    // matrix3d() (4x4)
+    mat4.set(
+      +c[0], -c[4],  +c[8], +c[12],
+      -c[1], +c[5],  -c[9], -c[13],
+      +c[2], -c[6], +c[10], +c[14],
+      +c[3], +c[7], +c[11], +c[15]
+    );
+  } else {
+    // handle 'none' or invalid values.
+    mat4.identity();
+  }
+};
+
 
 export default {
   parseTransformValue,
   parseOriginValue,
   parseUnitValue
-}
+};

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -73,9 +73,6 @@ const getTransformForElement = elem => {
 const getProjectionForElement = elem => {
   let perspectiveOrigin = new THREE.Vector3();
   let perspective;
-  let osParent = elem;
-  let posX = 0;
-  let posY = 0;
   let clipBounds = {
     left: 0,
     top: 0,

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -17,7 +17,7 @@ const getTransformForElement = elem => {
 
   // if this element doesn't have a width or height bail out now.
   if (elem.offsetWidth === 0 || elem.offsetHeight === 0) {
-    return m1
+    return m1;
   }
 
   posX -= elem.offsetWidth / 2;
@@ -66,8 +66,8 @@ const getTransformForElement = elem => {
     }
   }
 
-  return m1
-}
+  return m1;
+};
 
 
 const getProjectionForElement = elem => {
@@ -131,8 +131,8 @@ const getProjectionForElement = elem => {
     perspectiveOrigin: perspectiveOrigin,
     clipBounds: clipBounds,
     cameraBounds: cameraBounds
-  }
-}
+  };
+};
 
 
 
@@ -140,7 +140,7 @@ const createStylesheet = cssText => {
   let styleElem = document.createElement('style');
   styleElem.textContent = cssText;
   return styleElem;
-}
+};
 
 
 
@@ -148,4 +148,4 @@ export default {
   getTransformForElement,
   getProjectionForElement,
   createStylesheet
-}
+};

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -1,7 +1,7 @@
 /* While mapping objects to a DOM element, it's useful to have a bounding box
 to reference. Enabling this flag will produce just that, a 2D bounding rect
 that should match the related DOM element */
-const RENDER_OBJECT_BOUNDING_BOX = true;
+const RENDER_OBJECT_BOUNDING_BOX = false;
 
 
 const normalize = obj => {
@@ -14,7 +14,7 @@ const normalize = obj => {
   obj.position.multiplyScalar(-scale);
   obj.scale.set(scale, scale, scale);
   return obj;
-}
+};
 
 
 const createDebugBoundingBox = obj => {
@@ -23,7 +23,7 @@ const createDebugBoundingBox = obj => {
   let wireframe = new THREE.WireframeGeometry(geometry);
   let boundingBox = new THREE.LineSegments(wireframe, material);
   return boundingBox;
-}
+};
 
 
 const createContainer = obj => {
@@ -36,11 +36,11 @@ const createContainer = obj => {
   container.add(obj);
 
   return container;
-}
+};
 
 
 export default {
   normalize,
   createDebugBoundingBox,
   createContainer
-}
+};

--- a/src/utils/model.js
+++ b/src/utils/model.js
@@ -1,7 +1,7 @@
 /* While mapping objects to a DOM element, it's useful to have a bounding box
 to reference. Enabling this flag will produce just that, a 2D bounding rect
 that should match the related DOM element */
-const RENDER_OBJECT_BOUNDING_BOX = false;
+const RENDER_OBJECT_BOUNDING_BOX = true;
 
 
 const normalize = obj => {


### PR DESCRIPTION
This PR updates the renderer to support multiple perspective values and overflow clipping:

* An `<x-model>` element or any of its ancestors with a CSS `overflow` value of `scroll`, `hidden` or `auto` will cause the 3D model to be clipped to the relevant element bounding box.
* An `<x-model>` element will now honour the perspective`/ `perspective-origin` of an ancestor element, allowing multiple perspectives to be used in a single document.

### Example
The screengrab below shows the two identical objects. The left side shows ad object rendered with `overflow: scroll`. The right side shows the same object rendered with`overflow: visible`. Both elements have their own perspective values:

![screen shot 2018-04-15 at 20 37 40](https://user-images.githubusercontent.com/588665/38782533-f62ba1ca-40ec-11e8-9ee7-f4aaef6a15f3.png)
